### PR TITLE
Rename SKILLMAP roles to SKILLDOMAIN across codebase

### DIFF
--- a/src/app/client/src/app/modules/shared/services/config/roles.config.json
+++ b/src/app/client/src/app/modules/shared/services/config/roles.config.json
@@ -1,6 +1,6 @@
 {
     "headerDropdownRoles":{
-        "workSpaceRole" : ["SKILLMAP_CREATOR","SKILLMAP_REVIEWER","CONTENT_CREATOR" , "CONTENT_CREATION" , "CONTENT_REVIEWER" , "CONTENT_REVIEW" , "FLAG_REVIEWER" , "COURSE_MENTOR" ,"BOOK_REVIEWER", "BOOK_CREATOR"],
+        "workSpaceRole" : ["SKILLDOMAIN_CREATOR","SKILLDOMAIN_REVIEWER","CONTENT_CREATOR" , "CONTENT_CREATION" , "CONTENT_REVIEWER" , "CONTENT_REVIEW" , "FLAG_REVIEWER" , "COURSE_MENTOR" ,"BOOK_REVIEWER", "BOOK_CREATOR"],
         "adminDashboard" : ["ORG_ADMIN","SYSTEM_ADMINISTRATION","REPORT_VIEWER", "REPORT_ADMIN"],
         "announcementRole" : ["ANNOUNCEMENT_SENDER"],
         "myActivityRole" : ["CONTENT_CREATOR"],
@@ -10,7 +10,7 @@
     },
 
     "workSpaceRole":{
-       "createRole": ["SKILLMAP_CREATOR","CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
+       "createRole": ["SKILLDOMAIN_CREATOR","CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
        "trainingRole": ["CONTENT_CREATOR","CONTENT_CREATION"],
        "questionBankRole": ["CONTENT_CREATOR","CONTENT_CREATION"],
        "questionBankReviewerRole": ["CONTENT_REVIEWER","CONTENT_REVIEW"],
@@ -33,8 +33,8 @@
        "allContentRole": ["CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
        "collaboratingRole": ["CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
        "alltextbookRole": ["ORG_ADMIN"],
-       "skillmapRole": ["SKILLMAP_CREATOR"],
-       "skillmapReviewerRole": ["SKILLMAP_REVIEWER"]
+       "skillmapRole": ["SKILLDOMAIN_CREATOR"],
+       "skillmapReviewerRole": ["SKILLDOMAIN_REVIEWER"]
     },
     "organizationRole":{
 
@@ -44,8 +44,8 @@
     },
      "ROLES":{
        "announcement": ["ANNOUNCEMENT_SENDER"],
-       "workspace":["SKILLMAP_CREATOR","SKILLMAP_REVIEWER","CONTENT_CREATOR" , "CONTENT_CREATION" , "CONTENT_REVIEWER" , "CONTENT_REVIEW" , "FLAG_REVIEWER" , "COURSE_MENTOR" ,"BOOK_REVIEWER","BOOK_CREATOR"],
-       "createRole": ["SKILLMAP_CREATOR","SKILLMAP_REVIEWER","CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
+       "workspace":["SKILLDOMAIN_CREATOR","SKILLDOMAIN_REVIEWER","CONTENT_CREATOR" , "CONTENT_CREATION" , "CONTENT_REVIEWER" , "CONTENT_REVIEW" , "FLAG_REVIEWER" , "COURSE_MENTOR" ,"BOOK_REVIEWER","BOOK_CREATOR"],
+       "createRole": ["SKILLDOMAIN_CREATOR","SKILLDOMAIN_REVIEWER","CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
        "draftRole": ["CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
        "inreviewRole":["CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
        "publishedRole":["CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
@@ -65,18 +65,18 @@
        "alltextbookRole": ["ORG_ADMIN"],
        "uciAdmin": ["ORG_ADMIN"],
        "programDashboardRole":["PROGRAM_MANAGER","PROGRAM_DESIGNER"],
-       "skillmapRole": ["SKILLMAP_CREATOR"],
-       "skillmapReviewerRole": ["SKILLMAP_REVIEWER"],
+       "skillmapRole": ["SKILLDOMAIN_CREATOR"],
+       "skillmapReviewerRole": ["SKILLDOMAIN_REVIEWER"],
        "questionBankRole": ["CONTENT_CREATOR","CONTENT_CREATION"],
        "questionBankReviewerRole": ["CONTENT_REVIEWER","CONTENT_REVIEW"]
     }
     ,"WORKSPACEAUTHGARDROLES":[
     {
-        "roles":["SKILLMAP_CREATOR","CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
+        "roles":["SKILLDOMAIN_CREATOR","CONTENT_CREATOR","CONTENT_CREATION","CONTENT_REVIEWER","CONTENT_REVIEW","BOOK_CREATOR"],
         "roleName":"createRole","url":"workspace/content/create","tab":"CREATE"
     },
     {
-        "roles":["SKILLMAP_REVIEWER"],
+        "roles":["SKILLDOMAIN_REVIEWER"],
         "roleName":"skillmapReviewerRole","url":"workspace/content/skillmap-reviewer/1","tab":"CREATE"
     },
     {
@@ -123,11 +123,11 @@
         "roleName":"collaboratingRole","url":"workspace/content/collaborating-on","tab":"Collaborating On"
     },
     {
-        "roles":["SKILLMAP_CREATOR"],
+        "roles":["SKILLDOMAIN_CREATOR"],
         "roleName":"skillmapRole","url":"workspace/content/skillmap/1","tab":"Skill Domain"
     },
     {
-        "roles":["SKILLMAP_REVIEWER"],
+        "roles":["SKILLDOMAIN_REVIEWER"],
         "roleName":"skillmapReviewerRole","url":"workspace/content/skillmap-reviewer/1","tab":"Skill Domain Reviewer"
     },
     {

--- a/src/app/client/src/app/modules/workspace/components/create-content/create-content.component.ts
+++ b/src/app/client/src/app/modules/workspace/components/create-content/create-content.component.ts
@@ -153,7 +153,7 @@ export class CreateContentComponent implements OnInit, AfterViewInit {
     this.isQuestionBankReviewer = this.permissionService.checkRolesPermissions(['CONTENT_REVIEWER', 'CONTENT_REVIEW']);
     
     // Check if user only has skill map roles and should not see other content creation options
-    const hasSkillMapRoles = this.permissionService.checkRolesPermissions(['SKILLMAP_CREATOR', 'SKILLMAP_REVIEWER']);
+    const hasSkillMapRoles = this.permissionService.checkRolesPermissions(['SKILLDOMAIN_CREATOR', 'SKILLDOMAIN_REVIEWER']);
     const hasContentRoles = this.permissionService.checkRolesPermissions(['CONTENT_CREATOR', 'CONTENT_CREATION', 'CONTENT_REVIEWER', 'CONTENT_REVIEW', 'BOOK_CREATOR']);
     
     this.isSkillMapUser = hasSkillMapRoles && !hasContentRoles;

--- a/src/app/client/src/app/modules/workspace/components/skill-map-editor/skill-map-editor.component.ts
+++ b/src/app/client/src/app/modules/workspace/components/skill-map-editor/skill-map-editor.component.ts
@@ -289,8 +289,8 @@ export class SkillMapEditorComponent implements OnInit, OnDestroy {
     private publicDataService: PublicDataService,
     private skillMapTreeService: SkillMapTreeService
   ) {
-    this.isSkillMapCreator = this.permissionService.checkRolesPermissions(['SKILLMAP_CREATOR']);
-    this.isSkillMapReviewer = this.permissionService.checkRolesPermissions(['SKILLMAP_REVIEWER']);
+    this.isSkillMapCreator = this.permissionService.checkRolesPermissions(['SKILLDOMAIN_CREATOR']);
+    this.isSkillMapReviewer = this.permissionService.checkRolesPermissions(['SKILLDOMAIN_REVIEWER']);
   }
 
   ngOnInit(): void {

--- a/src/app/client/src/app/modules/workspace/components/skill-map/skill-map.component.ts
+++ b/src/app/client/src/app/modules/workspace/components/skill-map/skill-map.component.ts
@@ -231,8 +231,8 @@ export class SkillMapComponent extends WorkSpace implements OnInit, AfterViewIni
       'messageText': 'messages.stmsg.m0008'
     };
     this.sortingOptions = this.config.dropDownConfig.FILTER.RESOURCES.sortingOptions;
-    this.isSkillMapCreator = this.permissionService.checkRolesPermissions(['SKILLMAP_CREATOR']);
-    this.isSkillMapReviewer = this.permissionService.checkRolesPermissions(['SKILLMAP_REVIEWER']);
+    this.isSkillMapCreator = this.permissionService.checkRolesPermissions(['SKILLDOMAIN_CREATOR']);
+    this.isSkillMapReviewer = this.permissionService.checkRolesPermissions(['SKILLDOMAIN_REVIEWER']);
   }
 
   ngOnInit() {

--- a/src/app/helpers/whitelistApis.js
+++ b/src/app/helpers/whitelistApis.js
@@ -26,8 +26,8 @@ const ROLE = {
   ANONYMOUS: 'ANONYMOUS',
   PROGRAM_MANAGER: "PROGRAM_MANAGER",
   PROGRAM_DESIGNER: "PROGRAM_DESIGNER",
-  SKILLMAP_CREATOR: "SKILLMAP_CREATOR",
-  SKILLMAP_REVIEWER: "SKILLMAP_REVIEWER"
+  SKILLDOMAIN_CREATOR: "SKILLDOMAIN_CREATOR",
+  SKILLDOMAIN_REVIEWER: "SKILLDOMAIN_REVIEWER"
 };
 
 const API_LIST = {
@@ -269,7 +269,7 @@ const API_LIST = {
         ROLE.COURSE_CREATOR,
         ROLE.BOOK_CREATOR, ROLE.BOOK_REVIEWER,
         ROLE.FLAG_REVIEWER, ROLE.ORG_ADMIN,
-        ROLE.SKILLMAP_CREATOR, ROLE.SKILLMAP_REVIEWER
+        ROLE.SKILLDOMAIN_CREATOR, ROLE.SKILLDOMAIN_REVIEWER
       ]
     },
 
@@ -1179,8 +1179,8 @@ const API_LIST = {
         ROLE.BOOK_CREATOR,
         ROLE.CONTENT_REVIEWER,
         ROLE.BOOK_REVIEWER,
-        ROLE.SKILLMAP_CREATOR,
-        ROLE.SKILLMAP_REVIEWER
+        ROLE.SKILLDOMAIN_CREATOR,
+        ROLE.SKILLDOMAIN_REVIEWER
       ]
     },
 
@@ -1188,37 +1188,37 @@ const API_LIST = {
     '/content/framework/v1/create': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
     '/content/framework/v1/term/create': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
     '/content/framework/v1/term/update/:termCode': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
     '/content/framework/v1/update/:frameworkId': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
     '/content/framework/v1/publish/:frameworkId': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_REVIEWER
+        ROLE.SKILLDOMAIN_REVIEWER
       ]
     },
     '/content/framework/v1/category/create': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
 
@@ -1226,38 +1226,38 @@ const API_LIST = {
     '/content/framework/v3/reject/:frameworkId': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_REVIEWER
+        ROLE.SKILLDOMAIN_REVIEWER
       ]
     },
     '/content/framework/v3/term/retire/:termId': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
     '/content/framework/v1/term/read/:termId': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
     '/content/framework/v3/retire/:frameworkId': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
     '/content/framework/v3/review/:frameworkId': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR
+        ROLE.SKILLDOMAIN_CREATOR
       ]
     },
     '/content/framework/v3/read/:frameworkId': {
       checksNeeded: ['ROLE_CHECK'],
       ROLE_CHECK: [
-        ROLE.SKILLMAP_CREATOR,
-        ROLE.SKILLMAP_REVIEWER,
+        ROLE.SKILLDOMAIN_CREATOR,
+        ROLE.SKILLDOMAIN_REVIEWER,
       ]
     },
 


### PR DESCRIPTION
Replaces all instances of SKILLMAP_CREATOR and SKILLMAP_REVIEWER with SKILLDOMAIN_CREATOR and SKILLDOMAIN_REVIEWER in configuration, components, and API whitelisting. This change standardizes role naming for skill domain features and ensures consistent permission checks throughout the application.

# SunbirdEd - Portal
---

### Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
---

### Please choose applicable option 
#### Example
- [x] Applicable
- [ ] Not applicable

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
